### PR TITLE
Support hardlinks in builtin boot images

### DIFF
--- a/.virtualenv.dev-requirements.txt
+++ b/.virtualenv.dev-requirements.txt
@@ -17,12 +17,12 @@ setuptools
 tox
 
 # python unit testing framework
-pytest
+pytest < 7.0.0
 pytest-cov
 pytest-xdist
 
 # Rolling backport of unittest.mock for all Pythons
-mock
+mock < 5.0.0
 
 # Version-bump your software with a single command!
 bumpversion

--- a/kiwi/boot/image/builtin_kiwi.py
+++ b/kiwi/boot/image/builtin_kiwi.py
@@ -139,7 +139,7 @@ class BootImageKiwi(BootImageBase):
                 temp_boot_root_directory
             )
             data.sync_data(
-                options=['-a']
+                options=['-a', '-H', '-X', '-A', '--one-file-system']
             )
             boot_directory = temp_boot_root_directory + '/boot'
             Path.wipe(boot_directory)

--- a/test/unit/boot/image/builtin_kiwi_test.py
+++ b/test/unit/boot/image/builtin_kiwi_test.py
@@ -112,7 +112,9 @@ class TestBootImageKiwi:
         mock_sync.assert_called_once_with(
             'boot-root-directory/', 'temp-boot-directory'
         )
-        data.sync_data.assert_called_once_with(options=['-a'])
+        data.sync_data.assert_called_once_with(
+                options=['-a', '-H', '-X', '-A', '--one-file-system']
+        )
         mock_cpio.assert_called_once_with(
             ''.join(
                 [


### PR DESCRIPTION
This commit adds support for hardlinks in custom builtin boot images, it makes use of the same rsync flags that are being used to sync the root-tree into a filesystem image/device.

Fixes bsc#1207128